### PR TITLE
fix path without extension handling

### DIFF
--- a/public/creator/js/controllers/relationship/edit/embeddedInPreviewController.js
+++ b/public/creator/js/controllers/relationship/edit/embeddedInPreviewController.js
@@ -104,7 +104,7 @@ app.controller("embeddedInEditPreviewController", function($scope, $rootScope, $
         let mp4path = fullPath;
         let oggpath = fullPath;
         // if not extention in the url
-        if (videoExtension === undefined) {
+        if (videoExtension !== 'mp4' || videoExtension !== 'ogg') {
             mp4path = fullPath + '.mp4';
             oggpath = fullPath + '.ogg';
         }


### PR DESCRIPTION
Check whether there is a .mp4 or .ogg extension at the end of the video path and add one if this is not the case.