### PR TITLE
Pin threejs version & attempt migration to latest version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "angular-momentjs": "^0.2.2",
     "leaflet": "~0.7.x",
     "ui-leaflet": "^2.0.0",
-    "three.js": "threejs#*",
+    "threejs": "r132",
     "components-threejs": "^0.0.79",
     "ngclipboard": "^1.1.1",
     "mapbox-gl-js": "https://github.com/nicho90/mapbox-gl-js-bower.git#0.39.1",
@@ -39,8 +39,6 @@
   },
   "resolutions": {
     "angular": "1.8.0",
-    "angular-route": "1.8.0",
-    "angular-sanitize": "1.8.0",
-    "bootstrap": "v4.0.0-alpha.6"
+    "angular-sanitize": "1.8.0"
   }
 }

--- a/public/cms/index.html
+++ b/public/cms/index.html
@@ -57,7 +57,7 @@
 	<script src="../bower_components/three.js/build/three.min.js"></script>
 	<script src="../bower_components/three.js/examples/js/controls/TransformControls.js"></script>
 	<script src="../bower_components/three.js/examples/js/renderers/CSS3DRenderer.js"></script>
-	<script src="../bower_components/three.js/examples/js/Detector.js"></script>
+	<script src="../bower_components/three.js/examples/js/WebGL.js"></script>
 	<script src="../bower_components/three.js/examples/js/loaders/OBJLoader.js"></script>
 
 	<!--Leaflet + angular binding-->

--- a/public/creator/index.html
+++ b/public/creator/index.html
@@ -60,7 +60,7 @@
         <script src="../bower_components/three.js/build/three.min.js"></script>
         <script src="../bower_components/three.js/examples/js/controls/TransformControls.js"></script>
         <script src="../bower_components/three.js/examples/js/renderers/CSS3DRenderer.js"></script>
-        <script src="../bower_components/three.js/examples/js/Detector.js"></script>
+        <script src="../bower_components/three.js/examples/js/WebGL.js"></script>
         <script src="../bower_components/three.js/examples/js/loaders/OBJLoader.js"></script>
 
         <!-- Mapbox GL -->

--- a/public/viewer/index.html
+++ b/public/viewer/index.html
@@ -57,7 +57,7 @@
         <script src="../bower_components/three.js/build/three.min.js"></script>
         <script src="../bower_components/three.js/examples/js/controls/TransformControls.js"></script>
         <script src="../bower_components/three.js/examples/js/renderers/CSS3DRenderer.js"></script>
-        <script src="../bower_components/three.js/examples/js/Detector.js"></script>
+        <script src="../bower_components/three.js/examples/js/WebGL.js"></script>
         <script src="../bower_components/three.js/examples/js/loaders/OBJLoader.js"></script>
 
     </head>


### PR DESCRIPTION
I have no idea what version was originally used during development, as it was never explicitly specified.
I migrated an obvious missing-script problem, but there may be more API changes lingering.

By pinning the used version, this PR at least mitigates future upcoming issues.
We could also pin an old version (< r97), which is likely closer to what has been used for development.

fixes #66