### PR TITLE
length is set to 0 for outdoor and indoor location

### DIFF
--- a/controllers/locations/post.js
+++ b/controllers/locations/post.js
@@ -30,7 +30,7 @@ exports.request = function(req, res) {
                 location_uuid: location_uuid,
                 name: req.body.name,
                 description: req.body.description,
-                length: req.body.length,
+                length: (req.body.length) ? req.body.length : 0,
                 lat: req.body.lat,
                 lng: req.body.lng,
                 location_type: req.body.location_type

--- a/controllers/locations/put.js
+++ b/controllers/locations/put.js
@@ -49,7 +49,7 @@ exports.request = function(req, res) {
                 location_uuid: location_uuid,
                 name: req.body.name,
                 description: req.body.description,
-                length: req.body.length,
+                length: (req.body.length) ? req.body.length : 0,
                 lat: req.body.lat,
                 lng: req.body.lng,
                 location_type: req.body.location_type


### PR DESCRIPTION
Creating outdoor or indoor locations was not possible anymore, because no length was given. I fixed this, by setting the length to 0 if it is undefined.