### PR TITLE
Fix THREEJS bugs and implement overlay placement adjusting on window resize

### DIFF
--- a/public/cms/js/controllers/scenarioCreateNewController.js
+++ b/public/cms/js/controllers/scenarioCreateNewController.js
@@ -955,8 +955,6 @@ app.controller("scenarioCreateNewController", function ($scope, config, $authent
 
         // Render the scene
         var render = function () {
-            control.update();
-            requestAnimationFrame( render );
 
             if($scope.relationship.overlay_category === "picture" || $scope.relationship.overlay_category === "video" || $scope.relationship.overlay_category === "object"){
                 renderer.render($scope.scene, camera);
@@ -977,6 +975,8 @@ app.controller("scenarioCreateNewController", function ($scope, config, $authent
                 $scope.objectCSS.scale.y = $scope.object.scale.y / 100; // Scale it down again to show the right size
             }
         };
+        
+        control.addEventListener( 'change', render );
         render();
     };
 

--- a/public/cms/js/controllers/scenarioDetailController.js
+++ b/public/cms/js/controllers/scenarioDetailController.js
@@ -766,8 +766,6 @@ app.controller("scenarioDetailController", function ($scope, $rootScope, $route,
 
         // Render the scene
         var render = function () {
-            control.update();
-            requestAnimationFrame( render );
 
             if($scope.relationship.overlay_category === "picture" || $scope.relationship.overlay_category === "video" || $scope.relationship.overlay_category === "object" || $scope.relationship.overlay_category === "distance"){
                 renderer.render($scope.scene, camera);
@@ -788,6 +786,7 @@ app.controller("scenarioDetailController", function ($scope, $rootScope, $route,
                 $scope.objectCSS.scale.y = $scope.object.scale.y / 100; // Scale it down again to show the right size
             }
         };
+        control.addEventListener( 'change', render );
         render();
     };
 

--- a/public/creator/js/controllers/relationship/edit/embeddedInPreviewController.js
+++ b/public/creator/js/controllers/relationship/edit/embeddedInPreviewController.js
@@ -444,8 +444,6 @@ app.controller("embeddedInEditPreviewController", function($scope, $rootScope, $
 
         // Render the scene
         var render = function () {
-            control.update();
-            requestAnimationFrame( render );
 
             if($scope.relationship.overlay_category === "picture" || $scope.relationship.overlay_category === "distance"){
                 renderer.render($scope.scene, camera);
@@ -469,6 +467,7 @@ app.controller("embeddedInEditPreviewController", function($scope, $rootScope, $
                 renderer.render($scope.scene, camera);
             }
         };
+        control.addEventListener( 'change', render );
         render();
     };
 

--- a/public/viewer/js/controllers/mainController.js
+++ b/public/viewer/js/controllers/mainController.js
@@ -351,11 +351,31 @@ app.controller("mainController", function ($scope, $rootScope, $window, config, 
 
         // Render the scene
         var render = function () {
-            requestAnimationFrame(render);
             $scope.cssRenderer.render($scope.scene, $scope.camera);
             $scope.renderer.render($scope.scene, $scope.camera);
         };
 
+        // Update the scene
+        var updateOverlayScene = function () {
+            const width = $('#video-container').width();
+            const height = $('#video-container').height();
+            $scope.camera.aspect = width / height;
+            $scope.camera.updateProjectionMatrix();
+            $scope.renderer.setSize(width, height);
+            setCanvasDimensions($scope.renderer.domElement, width, height);
+            render();
+        };
+
+        // Adjust Canvas dimesnions to video canvas
+        var setCanvasDimensions = function(canvas, width, height) {
+            canvas.width = width;
+            canvas.height = height;
+            canvas.style.width = `${width}px`;
+            canvas.style.height = `${height}px`;
+        };
+ 
+        // Listen to window resize events to update content
+        window.addEventListener( 'resize', updateOverlayScene, false );
         render();
     };
 


### PR DESCRIPTION
- remove deprecated THREEJS update() function that had no functionality; 
- for overlay editing: stop rerendering scene in infinitly loop - instead rerender only if controls are used; 
- for viewer: stop infinite rerendering, instead implement rerendering on window resize event